### PR TITLE
fix(search): fix type/tags/search filters and add genres filter (#21)

### DIFF
--- a/.claude/skills/hf-designer/SKILL.md
+++ b/.claude/skills/hf-designer/SKILL.md
@@ -15,7 +15,9 @@ You are a senior UI/UX designer specializing in cyberpunk-inspired digital exper
 - Subtle opacity borders (e.g., `border-purple-500/20`), gradients for depth
 - Typography: monospace/geometric sans for headings, readable sans for body
 
-**UX:** Content-first. Never let decoration overwhelm movies/shows. Mobile-first, 150–300ms transitions, no heavy JS patterns.
+**UX:**
+- Content-first. Never let decoration overwhelm movies/shows. Mobile-first, 150–300ms transitions, no heavy JS patterns.
+- Clickable elements must have a hover state with a pointer cursor.
 
 **Accessibility:** 4.5:1 contrast for body text, 3:1 for large text. Visible focus states. 44×44px touch targets. Never color-only meaning.
 
@@ -30,3 +32,5 @@ You are a senior UI/UX designer specializing in cyberpunk-inspired digital exper
 Be decisive — max 2–3 options, always recommend one. Designs must be implementable with Tailwind CSS without custom CSS unless unavoidable.
 
 Before finalizing: ✓ cyberpunk aesthetic ✓ dark-mode primary ✓ responsive (375/768/1280px) ✓ WCAG AA ✓ valid Tailwind classes ✓ subtle transitions ✓ clear typographic hierarchy
+
+

--- a/.claude/skills/hf-product-manager/SKILL.md
+++ b/.claude/skills/hf-product-manager/SKILL.md
@@ -181,7 +181,7 @@ gh label create "PRB" --repo 6rian/hackerflix --color "7B2FBE" --description "Pr
 
 Always confirm the issue URL after creation so the user can review it.
 
-When an issue is blocked by a decision or question, add the "needs grooming" label, add a comment tagging the user:
+When an issue has open questions, is blocked by a decision or question, you **must** add the "needs grooming" label and leave a comment tagging the user. Always include an explanation and suggested answer.
 
 ```bash
 gh issue edit ISSUE_NUMBER --add-label "needs grooming"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN corepack enable
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
+COPY patches/ ./patches/
 
 FROM base AS dev
 RUN pnpm install --frozen-lockfile

--- a/app/controllers/search_controller.ts
+++ b/app/controllers/search_controller.ts
@@ -6,8 +6,8 @@ import { serializeMovie, serializeTvSeries } from '#serializers/media_serializer
 export default class SearchController {
   async index({ inertia }: HttpContext) {
     const [allMovies, allShows] = await Promise.all([
-      Movie.query().preload('keywords').orderBy('title', 'asc'),
-      TvSeries.query().preload('keywords').orderBy('name', 'asc'),
+      Movie.query().preload('keywords').preload('genres').orderBy('title', 'asc'),
+      TvSeries.query().preload('keywords').preload('genres').orderBy('name', 'asc'),
     ]);
 
     const movies = allMovies.map(serializeMovie);

--- a/app/serializers/media_serializer.ts
+++ b/app/serializers/media_serializer.ts
@@ -16,13 +16,14 @@ export interface MediaItem {
   slug: string;
   mediaType: 'movie' | 'tv';
   title: string;
-  type: 'movie' | 'show';
+  type: 'movie' | 'show' | 'documentary';
   year: string;
   rating: number;
   description: string;
   image: string;
   backdrop?: string;
   tags: MediaTag[];
+  genres: MediaTag[];
 }
 
 export interface CastMember {
@@ -58,20 +59,24 @@ export interface MediaDetails extends MediaItem {
 
 const CREW_ROLES = new Set(['Director', 'Writer', 'Screenplay', 'Producer', 'Creator']);
 
-// Both functions require keywords to be preloaded: .preload('keywords')
+// Both functions require keywords and genres to be preloaded: .preload('keywords').preload('genres')
+// When genres are not preloaded, type defaults to 'movie'/'show' and genres defaults to [].
 export function serializeMovie(movie: Movie): MediaItem {
+  // TMDB genre ID 99 = Documentary
+  const isDocumentary = movie.genres?.some((g) => g.id === 99) ?? false;
   return {
     id: movie.id,
     slug: movie.slug,
     mediaType: 'movie',
     title: movie.title,
-    type: 'movie',
+    type: isDocumentary ? 'documentary' : 'movie',
     year: movie.releaseDate ? movie.releaseDate.getFullYear().toString() : '',
     rating: movie.voteAverage ?? 0,
     description: movie.overview ?? '',
     image: movie.posterPath ? tmdbConfig.imageBaseUrl + movie.posterPath : '',
     backdrop: movie.backdropPath ? tmdbConfig.backdropBaseUrl + movie.backdropPath : undefined,
     tags: movie.keywords.map((k) => ({ name: k.name, slug: k.slug })),
+    genres: (movie.genres ?? []).map((g) => ({ name: g.name, slug: g.slug })),
   };
 }
 
@@ -88,6 +93,7 @@ export function serializeTvSeries(series: TvSeries): MediaItem {
     image: series.posterPath ? tmdbConfig.imageBaseUrl + series.posterPath : '',
     backdrop: series.backdropPath ? tmdbConfig.backdropBaseUrl + series.backdropPath : undefined,
     tags: series.keywords.map((k) => ({ name: k.name, slug: k.slug })),
+    genres: (series.genres ?? []).map((g) => ({ name: g.name, slug: g.slug })),
   };
 }
 

--- a/app/serializers/media_serializer.ts
+++ b/app/serializers/media_serializer.ts
@@ -59,8 +59,15 @@ export interface MediaDetails extends MediaItem {
 
 const CREW_ROLES = new Set(['Director', 'Writer', 'Screenplay', 'Producer', 'Creator']);
 
-// Both functions require keywords and genres to be preloaded: .preload('keywords').preload('genres')
-// When genres are not preloaded, type defaults to 'movie'/'show' and genres defaults to [].
+/**
+ * Serializes a Movie model to a MediaItem for client rendering.
+ *
+ * Sets `type` to `'documentary'` when TMDB genre ID 99 (Documentary) is present;
+ * otherwise `'movie'`. `genres` falls back to `[]` when the relation is not preloaded.
+ *
+ * @param movie - Movie model with `keywords` and `genres` preloaded.
+ * @returns Serialized MediaItem ready for Inertia props.
+ */
 export function serializeMovie(movie: Movie): MediaItem {
   // TMDB genre ID 99 = Documentary
   const isDocumentary = movie.genres?.some((g) => g.id === 99) ?? false;
@@ -80,6 +87,14 @@ export function serializeMovie(movie: Movie): MediaItem {
   };
 }
 
+/**
+ * Serializes a TvSeries model to a MediaItem for client rendering.
+ *
+ * `genres` falls back to `[]` when the relation is not preloaded.
+ *
+ * @param series - TvSeries model with `keywords` and `genres` preloaded.
+ * @returns Serialized MediaItem ready for Inertia props.
+ */
 export function serializeTvSeries(series: TvSeries): MediaItem {
   return {
     id: series.id,
@@ -97,8 +112,15 @@ export function serializeTvSeries(series: TvSeries): MediaItem {
   };
 }
 
-// Requires: .preload('keywords').preload('genres').preload('movieCredits', q => q.preload('person'))
-// Plus separately-queried images and videos.
+/**
+ * Serializes a Movie with its related media into a full MediaDetails object.
+ *
+ * @param movie - Movie model with `keywords`, `genres`, and `movieCredits` (+ `person`) preloaded.
+ * @param images - Separately queried Image records for the movie.
+ * @param videos - Separately queried Video records for the movie.
+ * @param credits - Separately queried MovieCredit records with `person` preloaded.
+ * @returns Full MediaDetails including cast, crew, images, and videos.
+ */
 export function serializeMovieDetails(
   movie: Movie,
   images: Image[],
@@ -158,8 +180,15 @@ export function serializeMovieDetails(
   };
 }
 
-// Requires: .preload('keywords').preload('genres').preload('tvCredits', q => q.preload('person'))
-// Plus separately-queried images and videos.
+/**
+ * Serializes a TvSeries with its related media into a full MediaDetails object.
+ *
+ * @param series - TvSeries model with `keywords`, `genres`, and `tvCredits` (+ `person`) preloaded.
+ * @param images - Separately queried Image records for the series.
+ * @param videos - Separately queried Video records for the series.
+ * @param credits - Separately queried TvCredit records with `person` preloaded.
+ * @returns Full MediaDetails including cast, crew, images, and videos.
+ */
 export function serializeTvSeriesDetails(
   series: TvSeries,
   images: Image[],

--- a/app/serializers/media_serializer.ts
+++ b/app/serializers/media_serializer.ts
@@ -70,7 +70,7 @@ const CREW_ROLES = new Set(['Director', 'Writer', 'Screenplay', 'Producer', 'Cre
  */
 export function serializeMovie(movie: Movie): MediaItem {
   // TMDB genre ID 99 = Documentary
-  const isDocumentary = movie.genres?.some((g) => g.id === 99) ?? false;
+  const isDocumentary = (movie.genres ?? []).some((g) => g.id === 99);
   return {
     id: movie.id,
     slug: movie.slug,

--- a/inertia/app/components/global/MediaListCard.tsx
+++ b/inertia/app/components/global/MediaListCard.tsx
@@ -51,7 +51,7 @@ export function MediaListCard({ media }: MediaListCardProps) {
           </div>
 
           {/* Synopsis/Description */}
-          <p className="text-foreground/80 mb-4 line-clamp-3 text-sm leading-relaxed">
+          <p className="text-foreground/80 mb-4 line-clamp-4 xl:line-clamp-6 text-sm leading-relaxed">
             {media.description}
           </p>
 

--- a/inertia/app/types/media.ts
+++ b/inertia/app/types/media.ts
@@ -15,6 +15,7 @@ export interface MediaItem {
   image: string;
   backdrop?: string;
   tags: MediaTag[];
+  genres: MediaTag[];
 }
 
 export interface CastMember {

--- a/inertia/css/theme.css
+++ b/inertia/css/theme.css
@@ -183,6 +183,7 @@
     padding: 0.5rem;
     border-radius: 0.5rem;
     transition: all 300ms;
+    cursor: pointer;
   }
   .neon-btn:hover {
     background-color: var(--muted);

--- a/inertia/pages/search.tsx
+++ b/inertia/pages/search.tsx
@@ -327,7 +327,7 @@ export default function Search() {
                     setShowSearchAutocomplete(false);
                     setSearchActiveIndex(-1);
                   }}
-                  className="text-muted-foreground absolute top-1/2 right-4 z-10 -translate-y-1/2 cursor-pointer transition-colors hover:text-foreground"
+                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-4 z-10 -translate-y-1/2 cursor-pointer transition-colors"
                   aria-label="Clear search"
                 >
                   <X className="h-4 w-4" />
@@ -465,7 +465,7 @@ export default function Search() {
                             isSelected
                               ? 'bg-[var(--deep-purple)] text-white'
                               : isFocused
-                                ? 'bg-muted/60 ring-1 ring-inset ring-[var(--electric-green)]/40'
+                                ? 'bg-muted/60 ring-1 ring-[var(--electric-green)]/40 ring-inset'
                                 : 'hover:bg-muted/80'
                           }`}
                         >
@@ -474,9 +474,7 @@ export default function Search() {
                       );
                     })}
                   </div>
-                  <p className="text-muted-foreground mt-1.5 text-xs">
-                    ↑↓ navigate · Space toggle
-                  </p>
+                  <p className="text-muted-foreground mt-1.5 text-xs">↑↓ navigate · Space toggle</p>
                 </div>
 
                 {/* Tags Filter */}

--- a/inertia/pages/search.tsx
+++ b/inertia/pages/search.tsx
@@ -171,10 +171,13 @@ export default function Search() {
   const clearFilters = () => {
     setSelectedTypes([]);
     setSelectedTags([]);
+    setTagInput('');
     setSelectedGenres([]);
+    setGenreInput('');
     setSearchQuery('');
     setSearchInput('');
-    setGenreInput('');
+    setShowTagAutocomplete(false);
+    setShowGenreAutocomplete(false);
   };
 
   const hasActiveFilters =
@@ -497,7 +500,7 @@ export default function Search() {
                     <button
                       key={genre}
                       onClick={() => removeGenre(genre)}
-                      className="font-hf-mono flex items-center gap-2 rounded-full bg-[var(--deep-purple)]/70 px-3 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/50"
+                      className="font-hf-mono flex items-center gap-2 rounded-full bg-[var(--deep-purple)] px-3 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/80"
                     >
                       {genre.toUpperCase()}
                       <X className="h-3 w-3" />

--- a/inertia/pages/search.tsx
+++ b/inertia/pages/search.tsx
@@ -145,7 +145,7 @@ export default function Search() {
     });
 
     return filtered;
-  }, [allMedia, searchQuery, selectedTypes, selectedTags, sortBy]);
+  }, [allMedia, searchQuery, selectedTypes, selectedTags, selectedGenres, sortBy]);
 
   // Clear all filters
   const clearFilters = () => {
@@ -333,6 +333,33 @@ export default function Search() {
                   </div>
                 </div>
 
+                {/* Genres Filter */}
+                <div>
+                  <h3 className="font-hf-mono mb-3 text-sm font-bold text-[var(--deep-purple)] dark:text-[var(--neon-cyan)]">
+                    GENRES
+                  </h3>
+                  <select
+                    multiple
+                    size={6}
+                    value={selectedGenres}
+                    onChange={(e) =>
+                      setSelectedGenres(
+                        Array.from(e.target.selectedOptions).map((o) => o.value)
+                      )
+                    }
+                    className="bg-card border-border w-full rounded-lg border text-sm transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:outline-none [&>option]:cursor-pointer [&>option]:px-3 [&>option]:py-2 [&>option:checked]:bg-[var(--deep-purple)] [&>option:checked]:text-white"
+                  >
+                    {allGenres.map((genre) => (
+                      <option key={genre} value={genre}>
+                        {genre}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-muted-foreground mt-1.5 text-xs">
+                    Hold ⌘/Ctrl to select multiple
+                  </p>
+                </div>
+
                 {/* Tags Filter */}
                 <div>
                   <h3 className="font-hf-mono mb-3 text-sm font-bold text-[var(--deep-purple)] dark:text-[var(--neon-cyan)]">
@@ -376,33 +403,6 @@ export default function Search() {
                       </div>
                     )}
                   </div>
-                </div>
-
-                {/* Genres Filter */}
-                <div>
-                  <h3 className="font-hf-mono mb-3 text-sm font-bold text-[var(--deep-purple)] dark:text-[var(--neon-cyan)]">
-                    GENRES
-                  </h3>
-                  <select
-                    multiple
-                    size={6}
-                    value={selectedGenres}
-                    onChange={(e) =>
-                      setSelectedGenres(
-                        Array.from(e.target.selectedOptions).map((o) => o.value)
-                      )
-                    }
-                    className="bg-card border-border w-full rounded-lg border text-sm transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:outline-none [&>option]:cursor-pointer [&>option]:px-3 [&>option]:py-2 [&>option:checked]:bg-[var(--deep-purple)] [&>option:checked]:text-white"
-                  >
-                    {allGenres.map((genre) => (
-                      <option key={genre} value={genre}>
-                        {genre}
-                      </option>
-                    ))}
-                  </select>
-                  <p className="text-muted-foreground mt-1.5 text-xs">
-                    Hold ⌘/Ctrl to select multiple
-                  </p>
                 </div>
               </div>
             </aside>
@@ -452,7 +452,7 @@ export default function Search() {
 
               {/* Media Grid */}
               {filteredMedia.length > 0 ? (
-                <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
                   {filteredMedia.map((media) => (
                     <MediaListCard key={`${media.mediaType}-${media.id}`} media={media} />
                   ))}

--- a/inertia/pages/search.tsx
+++ b/inertia/pages/search.tsx
@@ -22,39 +22,32 @@ export default function Search() {
   const [showFilters, setShowFilters] = useState(false);
   const [showSearchAutocomplete, setShowSearchAutocomplete] = useState(false);
   const [showTagAutocomplete, setShowTagAutocomplete] = useState(false);
+  const [searchActiveIndex, setSearchActiveIndex] = useState(-1);
+  const [tagActiveIndex, setTagActiveIndex] = useState(-1);
+  const [genreFocusIndex, setGenreFocusIndex] = useState(-1);
 
   const searchContainerRef = useRef<HTMLDivElement>(null);
   const tagContainerRef = useRef<HTMLDivElement>(null);
+  const searchItemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const tagItemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const genreItemRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
-  // Combine all media items
-  const allMedia: MediaItem[] = useMemo(() => {
-    return [...movies, ...shows];
-  }, [movies, shows]);
+  const allMedia: MediaItem[] = useMemo(() => [...movies, ...shows], [movies, shows]);
 
-  // Get all unique tag names
   const allTags = useMemo(() => {
     const tags = new Set<string>();
-    allMedia.forEach((item) => {
-      item.tags.forEach((tag) => tags.add(tag.name));
-    });
+    allMedia.forEach((item) => item.tags.forEach((tag) => tags.add(tag.name)));
     return Array.from(tags).sort();
   }, [allMedia]);
 
-  // Get all unique genre names
   const allGenres = useMemo(() => {
     const genres = new Set<string>();
-    allMedia.forEach((item) => {
-      item.genres.forEach((g) => genres.add(g.name));
-    });
+    allMedia.forEach((item) => item.genres.forEach((g) => genres.add(g.name)));
     return Array.from(genres).sort();
   }, [allMedia]);
 
-  // Get all unique titles for autocomplete
-  const allTitles = useMemo(() => {
-    return allMedia.map((item) => item.title).sort();
-  }, [allMedia]);
+  const allTitles = useMemo(() => allMedia.map((item) => item.title).sort(), [allMedia]);
 
-  // Filtered titles for search autocomplete
   const filteredTitles = useMemo(() => {
     if (!searchInput) return [];
     return allTitles
@@ -62,7 +55,6 @@ export default function Search() {
       .slice(0, 8);
   }, [searchInput, allTitles]);
 
-  // Filtered tags for tag autocomplete
   const filteredTagOptions = useMemo(() => {
     if (!tagInput) return [];
     return allTags
@@ -72,35 +64,24 @@ export default function Search() {
       .slice(0, 8);
   }, [tagInput, allTags, selectedTags]);
 
-  // Toggle type filter
   const toggleType = (type: MediaType) => {
     setSelectedTypes((prev) =>
       prev.includes(type) ? prev.filter((t) => t !== type) : [...prev, type]
     );
   };
 
-  // Add tag
   const addTag = (tag: string) => {
-    if (!selectedTags.includes(tag)) {
-      setSelectedTags((prev) => [...prev, tag]);
-    }
+    if (!selectedTags.includes(tag)) setSelectedTags((prev) => [...prev, tag]);
   };
 
-  // Remove tag
-  const removeTag = (tag: string) => {
-    setSelectedTags((prev) => prev.filter((t) => t !== tag));
-  };
+  const removeTag = (tag: string) => setSelectedTags((prev) => prev.filter((t) => t !== tag));
 
-  // Remove genre
-  const removeGenre = (genre: string) => {
+  const removeGenre = (genre: string) =>
     setSelectedGenres((prev) => prev.filter((g) => g !== genre));
-  };
 
-  // Filter and sort media
   const filteredMedia = useMemo(() => {
     let filtered = allMedia;
 
-    // Filter by search query
     if (searchQuery) {
       filtered = filtered.filter(
         (item) =>
@@ -109,27 +90,23 @@ export default function Search() {
       );
     }
 
-    // Filter by type
     if (selectedTypes.length > 0) {
       filtered = filtered.filter((item) => selectedTypes.includes(item.type));
     }
 
-    // Filter by tags (inclusive - match any selected tag)
     if (selectedTags.length > 0) {
       filtered = filtered.filter((item) =>
         item.tags.some((tag) => selectedTags.includes(tag.name))
       );
     }
 
-    // Filter by genres (inclusive - match any selected genre)
     if (selectedGenres.length > 0) {
       filtered = filtered.filter((item) =>
         item.genres.some((g) => selectedGenres.includes(g.name))
       );
     }
 
-    // Sort
-    filtered = [...filtered].sort((a, b) => {
+    return [...filtered].sort((a, b) => {
       switch (sortBy) {
         case 'title-asc':
           return a.title.localeCompare(b.title);
@@ -143,11 +120,8 @@ export default function Search() {
           return 0;
       }
     });
-
-    return filtered;
   }, [allMedia, searchQuery, selectedTypes, selectedTags, selectedGenres, sortBy]);
 
-  // Clear all filters
   const clearFilters = () => {
     setSelectedTypes([]);
     setSelectedTags([]);
@@ -156,48 +130,147 @@ export default function Search() {
     setSearchQuery('');
     setSearchInput('');
     setShowTagAutocomplete(false);
+    setShowSearchAutocomplete(false);
+    setSearchActiveIndex(-1);
+    setTagActiveIndex(-1);
   };
 
   const hasActiveFilters =
     selectedTypes.length > 0 || selectedTags.length > 0 || selectedGenres.length > 0 || searchQuery;
 
-  // Handle search input change
+  // Clears other filters when a search query is entered so they don't compete
   const handleSearchInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchInput(value);
     setSearchQuery(value);
     setShowSearchAutocomplete(value.length > 0);
+    setSearchActiveIndex(-1);
+    if (value.length > 0) {
+      setSelectedTypes([]);
+      setSelectedTags([]);
+      setTagInput('');
+      setSelectedGenres([]);
+    }
   };
 
-  // Handle search autocomplete select
   const handleSearchSelect = (title: string) => {
     setSearchQuery(title);
     setSearchInput(title);
     setShowSearchAutocomplete(false);
+    setSearchActiveIndex(-1);
   };
 
-  // Handle tag input change
+  const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!showSearchAutocomplete || filteredTitles.length === 0) {
+      if (e.key === 'Enter' || e.key === 'Escape') {
+        setShowSearchAutocomplete(false);
+        setSearchActiveIndex(-1);
+      }
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setSearchActiveIndex((i) => Math.min(i + 1, filteredTitles.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setSearchActiveIndex((i) => Math.max(i - 1, -1));
+        break;
+      case 'Enter':
+        e.preventDefault();
+        if (searchActiveIndex >= 0 && filteredTitles[searchActiveIndex]) {
+          handleSearchSelect(filteredTitles[searchActiveIndex]);
+        } else {
+          setShowSearchAutocomplete(false);
+        }
+        setSearchActiveIndex(-1);
+        break;
+      case 'Escape':
+        setShowSearchAutocomplete(false);
+        setSearchActiveIndex(-1);
+        break;
+    }
+  };
+
   const handleTagInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setTagInput(value);
     setShowTagAutocomplete(value.length > 0);
+    setTagActiveIndex(-1);
   };
 
-  // Handle tag autocomplete select
   const handleTagSelect = (tag: string) => {
     addTag(tag);
     setTagInput('');
     setShowTagAutocomplete(false);
+    setTagActiveIndex(-1);
   };
 
-  // Handle tag input key press
   const handleTagInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Backspace' && !tagInput && selectedTags.length > 0) {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (showTagAutocomplete && filteredTagOptions.length > 0) {
+        setTagActiveIndex((i) => Math.min(i + 1, filteredTagOptions.length - 1));
+      }
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (showTagAutocomplete) {
+        setTagActiveIndex((i) => Math.max(i - 1, -1));
+      }
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (showTagAutocomplete && tagActiveIndex >= 0 && filteredTagOptions[tagActiveIndex]) {
+        handleTagSelect(filteredTagOptions[tagActiveIndex]);
+      }
+    } else if (e.key === 'Escape') {
+      setShowTagAutocomplete(false);
+      setTagActiveIndex(-1);
+    } else if (e.key === 'Backspace' && !tagInput && selectedTags.length > 0) {
       removeTag(selectedTags[selectedTags.length - 1]);
     }
   };
 
-  // Click outside to close autocomplete
+  const handleGenreKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setGenreFocusIndex((i) => Math.min(i + 1, allGenres.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setGenreFocusIndex((i) => Math.max(i - 1, 0));
+        break;
+      case ' ':
+        e.preventDefault();
+        if (allGenres[genreFocusIndex] !== undefined) {
+          const genre = allGenres[genreFocusIndex];
+          setSelectedGenres((prev) =>
+            prev.includes(genre) ? prev.filter((g) => g !== genre) : [...prev, genre]
+          );
+        }
+        break;
+    }
+  };
+
+  useEffect(() => {
+    if (searchActiveIndex >= 0) {
+      searchItemRefs.current[searchActiveIndex]?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [searchActiveIndex]);
+
+  useEffect(() => {
+    if (tagActiveIndex >= 0) {
+      tagItemRefs.current[tagActiveIndex]?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [tagActiveIndex]);
+
+  useEffect(() => {
+    if (genreFocusIndex >= 0) {
+      genreItemRefs.current[genreFocusIndex]?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [genreFocusIndex]);
+
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
@@ -205,9 +278,11 @@ export default function Search() {
         !searchContainerRef.current.contains(event.target as Node)
       ) {
         setShowSearchAutocomplete(false);
+        setSearchActiveIndex(-1);
       }
       if (tagContainerRef.current && !tagContainerRef.current.contains(event.target as Node)) {
         setShowTagAutocomplete(false);
+        setTagActiveIndex(-1);
       }
     };
 
@@ -241,15 +316,35 @@ export default function Search() {
                 value={searchInput}
                 onChange={handleSearchInputChange}
                 onFocus={() => searchInput && setShowSearchAutocomplete(true)}
-                className="bg-card border-border w-full rounded-xl border py-4 pr-4 pl-12 transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:shadow-[0_0_20px_rgba(0,255,170,0.2)] focus:outline-none"
+                onKeyDown={handleSearchKeyDown}
+                className={`bg-card border-border w-full rounded-xl border py-4 pl-12 transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:shadow-[0_0_20px_rgba(0,255,170,0.2)] focus:outline-none ${searchQuery ? 'pr-12' : 'pr-4'}`}
               />
+              {searchQuery && (
+                <button
+                  onClick={() => {
+                    setSearchQuery('');
+                    setSearchInput('');
+                    setShowSearchAutocomplete(false);
+                    setSearchActiveIndex(-1);
+                  }}
+                  className="text-muted-foreground absolute top-1/2 right-4 z-10 -translate-y-1/2 cursor-pointer transition-colors hover:text-foreground"
+                  aria-label="Clear search"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
               {showSearchAutocomplete && filteredTitles.length > 0 && (
                 <div className="bg-card border-border absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-y-auto rounded-xl border shadow-lg">
-                  {filteredTitles.map((title) => (
+                  {filteredTitles.map((title, index) => (
                     <button
                       key={title}
+                      ref={(el) => {
+                        searchItemRefs.current[index] = el;
+                      }}
                       onClick={() => handleSearchSelect(title)}
-                      className="hover:bg-muted/80 w-full px-4 py-3 text-left transition-all duration-200 first:rounded-t-xl last:rounded-b-xl"
+                      className={`w-full cursor-pointer px-4 py-3 text-left transition-all duration-200 first:rounded-t-xl last:rounded-b-xl ${
+                        index === searchActiveIndex ? 'bg-muted/80' : 'hover:bg-muted/80'
+                      }`}
                     >
                       <span className="text-sm">{title}</span>
                     </button>
@@ -263,7 +358,7 @@ export default function Search() {
           <div className="mb-6 lg:hidden">
             <button
               onClick={() => setShowFilters(!showFilters)}
-              className="font-hf-mono bg-card border-border flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all duration-300 hover:border-[var(--electric-green)]/40"
+              className="font-hf-mono bg-card border-border flex cursor-pointer items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium transition-all duration-300 hover:border-[var(--electric-green)]/40"
             >
               <SlidersHorizontal className="h-4 w-4" />
               {showFilters ? 'HIDE_FILTERS' : 'SHOW_FILTERS'}
@@ -288,7 +383,7 @@ export default function Search() {
                 {hasActiveFilters && (
                   <button
                     onClick={clearFilters}
-                    className="font-hf-mono bg-muted text-muted-foreground hover:bg-muted/80 w-full rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300"
+                    className="font-hf-mono w-full cursor-pointer rounded-lg border border-[var(--deep-purple)]/40 bg-[var(--deep-purple)]/10 px-4 py-2 text-sm font-medium text-[var(--deep-purple)] transition-all duration-300 hover:bg-[var(--deep-purple)]/20 dark:border-[var(--electric-green)]/30 dark:bg-[var(--electric-green)]/10 dark:text-[var(--electric-green)] dark:hover:bg-[var(--electric-green)]/20"
                   >
                     CLEAR_ALL
                   </button>
@@ -302,7 +397,7 @@ export default function Search() {
                   <select
                     value={sortBy}
                     onChange={(e) => setSortBy(e.target.value as SortOption)}
-                    className="bg-card border-border w-full rounded-lg border px-3 py-2 text-sm transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:outline-none"
+                    className="bg-card border-border w-full cursor-pointer rounded-lg border px-3 py-2 text-sm transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:outline-none"
                   >
                     <option value="title-asc">Title (A-Z)</option>
                     <option value="title-desc">Title (Z-A)</option>
@@ -333,30 +428,54 @@ export default function Search() {
                   </div>
                 </div>
 
-                {/* Genres Filter */}
+                {/* Genres Filter — custom accessible listbox */}
                 <div>
                   <h3 className="font-hf-mono mb-3 text-sm font-bold text-[var(--deep-purple)] dark:text-[var(--neon-cyan)]">
                     GENRES
                   </h3>
-                  <select
-                    multiple
-                    size={6}
-                    value={selectedGenres}
-                    onChange={(e) =>
-                      setSelectedGenres(
-                        Array.from(e.target.selectedOptions).map((o) => o.value)
-                      )
-                    }
-                    className="bg-card border-border w-full rounded-lg border text-sm transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:outline-none [&>option]:cursor-pointer [&>option]:px-3 [&>option]:py-2 [&>option:checked]:bg-[var(--deep-purple)] [&>option:checked]:text-white"
+                  <div
+                    tabIndex={0}
+                    role="listbox"
+                    aria-multiselectable="true"
+                    aria-label="Genres"
+                    onKeyDown={handleGenreKeyDown}
+                    className="bg-card border-border max-h-48 overflow-y-auto rounded-lg border focus:border-[var(--electric-green)]/40 focus:outline-none"
                   >
-                    {allGenres.map((genre) => (
-                      <option key={genre} value={genre}>
-                        {genre}
-                      </option>
-                    ))}
-                  </select>
+                    {allGenres.map((genre, index) => {
+                      const isSelected = selectedGenres.includes(genre);
+                      const isFocused = index === genreFocusIndex;
+                      return (
+                        <button
+                          key={genre}
+                          ref={(el) => {
+                            genreItemRefs.current[index] = el;
+                          }}
+                          role="option"
+                          aria-selected={isSelected}
+                          tabIndex={-1}
+                          onClick={() => {
+                            setSelectedGenres((prev) =>
+                              prev.includes(genre)
+                                ? prev.filter((g) => g !== genre)
+                                : [...prev, genre]
+                            );
+                            setGenreFocusIndex(index);
+                          }}
+                          className={`w-full cursor-pointer px-3 py-2 text-left text-sm transition-colors duration-150 ${
+                            isSelected
+                              ? 'bg-[var(--deep-purple)] text-white'
+                              : isFocused
+                                ? 'bg-muted/60 ring-1 ring-inset ring-[var(--electric-green)]/40'
+                                : 'hover:bg-muted/80'
+                          }`}
+                        >
+                          {genre}
+                        </button>
+                      );
+                    })}
+                  </div>
                   <p className="text-muted-foreground mt-1.5 text-xs">
-                    Hold ⌘/Ctrl to select multiple
+                    ↑↓ navigate · Space toggle
                   </p>
                 </div>
 
@@ -366,13 +485,12 @@ export default function Search() {
                     TAGS
                   </h3>
                   <div className="relative" ref={tagContainerRef}>
-                    {/* Tag Input with Selected Tags */}
                     <div className="bg-card border-border flex flex-wrap gap-2 rounded-lg border p-2 transition-all duration-300 focus-within:border-[var(--electric-green)]/40 focus-within:shadow-[0_0_20px_rgba(0,255,170,0.2)]">
                       {selectedTags.map((tag) => (
                         <button
                           key={tag}
                           onClick={() => removeTag(tag)}
-                          className="font-hf-mono flex items-center gap-1 rounded bg-[var(--deep-purple)] px-2 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/80"
+                          className="font-hf-mono flex cursor-pointer items-center gap-1 rounded bg-[var(--deep-purple)] px-2 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/80"
                         >
                           {tag}
                           <X className="h-3 w-3" />
@@ -388,14 +506,18 @@ export default function Search() {
                         className="min-w-[120px] flex-1 bg-transparent text-sm outline-none"
                       />
                     </div>
-                    {/* Tag Autocomplete Dropdown */}
                     {showTagAutocomplete && filteredTagOptions.length > 0 && (
                       <div className="bg-card border-border absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-y-auto rounded-xl border shadow-lg">
-                        {filteredTagOptions.map((tag) => (
+                        {filteredTagOptions.map((tag, index) => (
                           <button
                             key={tag}
+                            ref={(el) => {
+                              tagItemRefs.current[index] = el;
+                            }}
                             onClick={() => handleTagSelect(tag)}
-                            className="hover:bg-muted/80 w-full px-4 py-2 text-left text-sm transition-all duration-200 first:rounded-t-xl last:rounded-b-xl"
+                            className={`w-full cursor-pointer px-4 py-2 text-left text-sm transition-all duration-200 first:rounded-t-xl last:rounded-b-xl ${
+                              index === tagActiveIndex ? 'bg-muted/80' : 'hover:bg-muted/80'
+                            }`}
                           >
                             {tag}
                           </button>
@@ -416,7 +538,7 @@ export default function Search() {
                     <button
                       key={type}
                       onClick={() => toggleType(type)}
-                      className="font-hf-mono flex items-center gap-2 rounded-full bg-[var(--deep-purple)] px-3 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/80"
+                      className="font-hf-mono flex cursor-pointer items-center gap-2 rounded-full bg-[var(--deep-purple)] px-3 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/80"
                     >
                       {type === 'show' ? 'TV SHOW' : type.toUpperCase()}
                       <X className="h-3 w-3" />
@@ -426,7 +548,7 @@ export default function Search() {
                     <button
                       key={tag}
                       onClick={() => removeTag(tag)}
-                      className="font-hf-mono bg-muted text-muted-foreground hover:bg-muted/80 flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium transition-all duration-200"
+                      className="font-hf-mono bg-muted text-muted-foreground hover:bg-muted/80 flex cursor-pointer items-center gap-2 rounded-full px-3 py-1 text-xs font-medium transition-all duration-200"
                     >
                       {tag.toUpperCase()}
                       <X className="h-3 w-3" />
@@ -436,7 +558,7 @@ export default function Search() {
                     <button
                       key={genre}
                       onClick={() => removeGenre(genre)}
-                      className="font-hf-mono flex items-center gap-2 rounded-full bg-[var(--deep-purple)] px-3 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/80"
+                      className="font-hf-mono flex cursor-pointer items-center gap-2 rounded-full bg-[var(--deep-purple)] px-3 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/80"
                     >
                       {genre.toUpperCase()}
                       <X className="h-3 w-3" />
@@ -452,7 +574,7 @@ export default function Search() {
 
               {/* Media Grid */}
               {filteredMedia.length > 0 ? (
-                <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
                   {filteredMedia.map((media) => (
                     <MediaListCard key={`${media.mediaType}-${media.id}`} media={media} />
                   ))}

--- a/inertia/pages/search.tsx
+++ b/inertia/pages/search.tsx
@@ -362,21 +362,24 @@ export default function Search() {
                   <h3 className="font-hf-mono mb-3 text-sm font-bold text-[var(--deep-purple)] dark:text-[var(--neon-cyan)]">
                     TYPE
                   </h3>
-                  <div className="space-y-2">
-                    {(['movie', 'show', 'documentary'] as MediaType[]).map((type) => (
-                      <label key={type} className="group flex cursor-pointer items-center gap-2">
-                        <input
-                          type="checkbox"
-                          checked={selectedTypes.includes(type)}
-                          onChange={() => toggleType(type)}
-                          className="border-border h-4 w-4 cursor-pointer rounded accent-[var(--deep-purple)]"
-                        />
-                        <span className="text-sm capitalize transition-colors duration-200 group-hover:text-[var(--deep-purple)] dark:group-hover:text-[var(--neon-cyan)]">
-                          {type === 'show' ? 'TV Show' : type}
-                        </span>
-                      </label>
-                    ))}
-                  </div>
+                  <select
+                    multiple
+                    size={3}
+                    value={selectedTypes}
+                    onChange={(e) =>
+                      setSelectedTypes(
+                        Array.from(e.target.selectedOptions).map((o) => o.value as MediaType)
+                      )
+                    }
+                    className="bg-card border-border w-full rounded-lg border text-sm transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:outline-none [&>option]:cursor-pointer [&>option]:px-3 [&>option]:py-2 [&>option:checked]:bg-[var(--deep-purple)] [&>option:checked]:text-white"
+                  >
+                    <option value="movie">Movie</option>
+                    <option value="show">TV Show</option>
+                    <option value="documentary">Documentary</option>
+                  </select>
+                  <p className="text-muted-foreground mt-1.5 text-xs">
+                    Hold ⌘/Ctrl to select multiple
+                  </p>
                 </div>
 
                 {/* Tags Filter */}

--- a/inertia/pages/search.tsx
+++ b/inertia/pages/search.tsx
@@ -17,13 +17,17 @@ export default function Search() {
   const [selectedTypes, setSelectedTypes] = useState<MediaType[]>([]);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState('');
+  const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
+  const [genreInput, setGenreInput] = useState('');
   const [sortBy, setSortBy] = useState<SortOption>('title-asc');
   const [showFilters, setShowFilters] = useState(false);
   const [showSearchAutocomplete, setShowSearchAutocomplete] = useState(false);
   const [showTagAutocomplete, setShowTagAutocomplete] = useState(false);
+  const [showGenreAutocomplete, setShowGenreAutocomplete] = useState(false);
 
   const searchContainerRef = useRef<HTMLDivElement>(null);
   const tagContainerRef = useRef<HTMLDivElement>(null);
+  const genreContainerRef = useRef<HTMLDivElement>(null);
 
   // Combine all media items
   const allMedia: MediaItem[] = useMemo(() => {
@@ -37,6 +41,15 @@ export default function Search() {
       item.tags.forEach((tag) => tags.add(tag.name));
     });
     return Array.from(tags).sort();
+  }, [allMedia]);
+
+  // Get all unique genre names
+  const allGenres = useMemo(() => {
+    const genres = new Set<string>();
+    allMedia.forEach((item) => {
+      item.genres.forEach((g) => genres.add(g.name));
+    });
+    return Array.from(genres).sort();
   }, [allMedia]);
 
   // Get all unique titles for autocomplete
@@ -62,6 +75,16 @@ export default function Search() {
       .slice(0, 8);
   }, [tagInput, allTags, selectedTags]);
 
+  // Filtered genres for genre autocomplete
+  const filteredGenreOptions = useMemo(() => {
+    if (!genreInput) return [];
+    return allGenres
+      .filter(
+        (g) => g.toLowerCase().includes(genreInput.toLowerCase()) && !selectedGenres.includes(g)
+      )
+      .slice(0, 8);
+  }, [genreInput, allGenres, selectedGenres]);
+
   // Toggle type filter
   const toggleType = (type: MediaType) => {
     setSelectedTypes((prev) =>
@@ -79,6 +102,18 @@ export default function Search() {
   // Remove tag
   const removeTag = (tag: string) => {
     setSelectedTags((prev) => prev.filter((t) => t !== tag));
+  };
+
+  // Add genre
+  const addGenre = (genre: string) => {
+    if (!selectedGenres.includes(genre)) {
+      setSelectedGenres((prev) => [...prev, genre]);
+    }
+  };
+
+  // Remove genre
+  const removeGenre = (genre: string) => {
+    setSelectedGenres((prev) => prev.filter((g) => g !== genre));
   };
 
   // Filter and sort media
@@ -106,6 +141,13 @@ export default function Search() {
       );
     }
 
+    // Filter by genres (inclusive - match any selected genre)
+    if (selectedGenres.length > 0) {
+      filtered = filtered.filter((item) =>
+        item.genres.some((g) => selectedGenres.includes(g.name))
+      );
+    }
+
     // Sort
     filtered = [...filtered].sort((a, b) => {
       switch (sortBy) {
@@ -129,11 +171,14 @@ export default function Search() {
   const clearFilters = () => {
     setSelectedTypes([]);
     setSelectedTags([]);
+    setSelectedGenres([]);
     setSearchQuery('');
     setSearchInput('');
+    setGenreInput('');
   };
 
-  const hasActiveFilters = selectedTypes.length > 0 || selectedTags.length > 0 || searchQuery;
+  const hasActiveFilters =
+    selectedTypes.length > 0 || selectedTags.length > 0 || selectedGenres.length > 0 || searchQuery;
 
   // Handle search input change
   const handleSearchInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -171,6 +216,27 @@ export default function Search() {
     }
   };
 
+  // Handle genre input change
+  const handleGenreInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setGenreInput(value);
+    setShowGenreAutocomplete(value.length > 0);
+  };
+
+  // Handle genre autocomplete select
+  const handleGenreSelect = (genre: string) => {
+    addGenre(genre);
+    setGenreInput('');
+    setShowGenreAutocomplete(false);
+  };
+
+  // Handle genre input key press
+  const handleGenreInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace' && !genreInput && selectedGenres.length > 0) {
+      removeGenre(selectedGenres[selectedGenres.length - 1]);
+    }
+  };
+
   // Click outside to close autocomplete
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -182,6 +248,12 @@ export default function Search() {
       }
       if (tagContainerRef.current && !tagContainerRef.current.contains(event.target as Node)) {
         setShowTagAutocomplete(false);
+      }
+      if (
+        genreContainerRef.current &&
+        !genreContainerRef.current.contains(event.target as Node)
+      ) {
+        setShowGenreAutocomplete(false);
       }
     };
 
@@ -243,7 +315,7 @@ export default function Search() {
               {showFilters ? 'HIDE_FILTERS' : 'SHOW_FILTERS'}
               {hasActiveFilters && (
                 <span className="text-background ml-1 rounded-full bg-[var(--electric-green)] px-2 py-0.5 text-xs">
-                  {selectedTypes.length + selectedTags.length + (searchQuery ? 1 : 0)}
+                  {selectedTypes.length + selectedTags.length + selectedGenres.length + (searchQuery ? 1 : 0)}
                 </span>
               )}
             </button>
@@ -348,6 +420,51 @@ export default function Search() {
                     )}
                   </div>
                 </div>
+
+                {/* Genres Filter */}
+                <div>
+                  <h3 className="font-hf-mono mb-3 text-sm font-bold text-[var(--deep-purple)] dark:text-[var(--neon-cyan)]">
+                    GENRES
+                  </h3>
+                  <div className="relative" ref={genreContainerRef}>
+                    {/* Genre Input with Selected Genres */}
+                    <div className="bg-card border-border flex flex-wrap gap-2 rounded-lg border p-2 transition-all duration-300 focus-within:border-[var(--electric-green)]/40 focus-within:shadow-[0_0_20px_rgba(0,255,170,0.2)]">
+                      {selectedGenres.map((genre) => (
+                        <button
+                          key={genre}
+                          onClick={() => removeGenre(genre)}
+                          className="font-hf-mono flex items-center gap-1 rounded bg-[var(--deep-purple)] px-2 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/80"
+                        >
+                          {genre}
+                          <X className="h-3 w-3" />
+                        </button>
+                      ))}
+                      <input
+                        type="text"
+                        placeholder={selectedGenres.length === 0 ? 'Type to search genres...' : ''}
+                        value={genreInput}
+                        onChange={handleGenreInputChange}
+                        onKeyDown={handleGenreInputKeyDown}
+                        onFocus={() => genreInput && setShowGenreAutocomplete(true)}
+                        className="min-w-[120px] flex-1 bg-transparent text-sm outline-none"
+                      />
+                    </div>
+                    {/* Genre Autocomplete Dropdown */}
+                    {showGenreAutocomplete && filteredGenreOptions.length > 0 && (
+                      <div className="bg-card border-border absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-y-auto rounded-xl border shadow-lg">
+                        {filteredGenreOptions.map((genre) => (
+                          <button
+                            key={genre}
+                            onClick={() => handleGenreSelect(genre)}
+                            className="hover:bg-muted/80 w-full px-4 py-2 text-left text-sm transition-all duration-200 first:rounded-t-xl last:rounded-b-xl"
+                          >
+                            {genre}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
               </div>
             </aside>
 
@@ -376,6 +493,16 @@ export default function Search() {
                       <X className="h-3 w-3" />
                     </button>
                   ))}
+                  {selectedGenres.map((genre) => (
+                    <button
+                      key={genre}
+                      onClick={() => removeGenre(genre)}
+                      className="font-hf-mono flex items-center gap-2 rounded-full bg-[var(--deep-purple)]/70 px-3 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/50"
+                    >
+                      {genre.toUpperCase()}
+                      <X className="h-3 w-3" />
+                    </button>
+                  ))}
                 </div>
               )}
 
@@ -388,7 +515,7 @@ export default function Search() {
               {filteredMedia.length > 0 ? (
                 <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
                   {filteredMedia.map((media) => (
-                    <MediaListCard key={media.id} media={media} />
+                    <MediaListCard key={`${media.mediaType}-${media.id}`} media={media} />
                   ))}
                 </div>
               ) : (

--- a/inertia/pages/search.tsx
+++ b/inertia/pages/search.tsx
@@ -18,16 +18,13 @@ export default function Search() {
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState('');
   const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
-  const [genreInput, setGenreInput] = useState('');
   const [sortBy, setSortBy] = useState<SortOption>('title-asc');
   const [showFilters, setShowFilters] = useState(false);
   const [showSearchAutocomplete, setShowSearchAutocomplete] = useState(false);
   const [showTagAutocomplete, setShowTagAutocomplete] = useState(false);
-  const [showGenreAutocomplete, setShowGenreAutocomplete] = useState(false);
 
   const searchContainerRef = useRef<HTMLDivElement>(null);
   const tagContainerRef = useRef<HTMLDivElement>(null);
-  const genreContainerRef = useRef<HTMLDivElement>(null);
 
   // Combine all media items
   const allMedia: MediaItem[] = useMemo(() => {
@@ -75,16 +72,6 @@ export default function Search() {
       .slice(0, 8);
   }, [tagInput, allTags, selectedTags]);
 
-  // Filtered genres for genre autocomplete
-  const filteredGenreOptions = useMemo(() => {
-    if (!genreInput) return [];
-    return allGenres
-      .filter(
-        (g) => g.toLowerCase().includes(genreInput.toLowerCase()) && !selectedGenres.includes(g)
-      )
-      .slice(0, 8);
-  }, [genreInput, allGenres, selectedGenres]);
-
   // Toggle type filter
   const toggleType = (type: MediaType) => {
     setSelectedTypes((prev) =>
@@ -102,13 +89,6 @@ export default function Search() {
   // Remove tag
   const removeTag = (tag: string) => {
     setSelectedTags((prev) => prev.filter((t) => t !== tag));
-  };
-
-  // Add genre
-  const addGenre = (genre: string) => {
-    if (!selectedGenres.includes(genre)) {
-      setSelectedGenres((prev) => [...prev, genre]);
-    }
   };
 
   // Remove genre
@@ -173,11 +153,9 @@ export default function Search() {
     setSelectedTags([]);
     setTagInput('');
     setSelectedGenres([]);
-    setGenreInput('');
     setSearchQuery('');
     setSearchInput('');
     setShowTagAutocomplete(false);
-    setShowGenreAutocomplete(false);
   };
 
   const hasActiveFilters =
@@ -219,27 +197,6 @@ export default function Search() {
     }
   };
 
-  // Handle genre input change
-  const handleGenreInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value;
-    setGenreInput(value);
-    setShowGenreAutocomplete(value.length > 0);
-  };
-
-  // Handle genre autocomplete select
-  const handleGenreSelect = (genre: string) => {
-    addGenre(genre);
-    setGenreInput('');
-    setShowGenreAutocomplete(false);
-  };
-
-  // Handle genre input key press
-  const handleGenreInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Backspace' && !genreInput && selectedGenres.length > 0) {
-      removeGenre(selectedGenres[selectedGenres.length - 1]);
-    }
-  };
-
   // Click outside to close autocomplete
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -251,9 +208,6 @@ export default function Search() {
       }
       if (tagContainerRef.current && !tagContainerRef.current.contains(event.target as Node)) {
         setShowTagAutocomplete(false);
-      }
-      if (genreContainerRef.current && !genreContainerRef.current.contains(event.target as Node)) {
-        setShowGenreAutocomplete(false);
       }
     };
 
@@ -362,24 +316,21 @@ export default function Search() {
                   <h3 className="font-hf-mono mb-3 text-sm font-bold text-[var(--deep-purple)] dark:text-[var(--neon-cyan)]">
                     TYPE
                   </h3>
-                  <select
-                    multiple
-                    size={3}
-                    value={selectedTypes}
-                    onChange={(e) =>
-                      setSelectedTypes(
-                        Array.from(e.target.selectedOptions).map((o) => o.value as MediaType)
-                      )
-                    }
-                    className="bg-card border-border w-full rounded-lg border text-sm transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:outline-none [&>option]:cursor-pointer [&>option]:px-3 [&>option]:py-2 [&>option:checked]:bg-[var(--deep-purple)] [&>option:checked]:text-white"
-                  >
-                    <option value="movie">Movie</option>
-                    <option value="show">TV Show</option>
-                    <option value="documentary">Documentary</option>
-                  </select>
-                  <p className="text-muted-foreground mt-1.5 text-xs">
-                    Hold ⌘/Ctrl to select multiple
-                  </p>
+                  <div className="space-y-2">
+                    {(['movie', 'show', 'documentary'] as MediaType[]).map((type) => (
+                      <label key={type} className="group flex cursor-pointer items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={selectedTypes.includes(type)}
+                          onChange={() => toggleType(type)}
+                          className="border-border h-4 w-4 cursor-pointer rounded accent-[var(--deep-purple)]"
+                        />
+                        <span className="text-sm capitalize transition-colors duration-200 group-hover:text-[var(--deep-purple)] dark:group-hover:text-[var(--neon-cyan)]">
+                          {type === 'show' ? 'TV Show' : type}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
                 </div>
 
                 {/* Tags Filter */}
@@ -432,44 +383,26 @@ export default function Search() {
                   <h3 className="font-hf-mono mb-3 text-sm font-bold text-[var(--deep-purple)] dark:text-[var(--neon-cyan)]">
                     GENRES
                   </h3>
-                  <div className="relative" ref={genreContainerRef}>
-                    {/* Genre Input with Selected Genres */}
-                    <div className="bg-card border-border flex flex-wrap gap-2 rounded-lg border p-2 transition-all duration-300 focus-within:border-[var(--electric-green)]/40 focus-within:shadow-[0_0_20px_rgba(0,255,170,0.2)]">
-                      {selectedGenres.map((genre) => (
-                        <button
-                          key={genre}
-                          onClick={() => removeGenre(genre)}
-                          className="font-hf-mono flex items-center gap-1 rounded bg-[var(--deep-purple)] px-2 py-1 text-xs font-medium text-white transition-all duration-200 hover:bg-[var(--deep-purple)]/80"
-                        >
-                          {genre}
-                          <X className="h-3 w-3" />
-                        </button>
-                      ))}
-                      <input
-                        type="text"
-                        placeholder={selectedGenres.length === 0 ? 'Type to search genres...' : ''}
-                        value={genreInput}
-                        onChange={handleGenreInputChange}
-                        onKeyDown={handleGenreInputKeyDown}
-                        onFocus={() => genreInput && setShowGenreAutocomplete(true)}
-                        className="min-w-[120px] flex-1 bg-transparent text-sm outline-none"
-                      />
-                    </div>
-                    {/* Genre Autocomplete Dropdown */}
-                    {showGenreAutocomplete && filteredGenreOptions.length > 0 && (
-                      <div className="bg-card border-border absolute top-full right-0 left-0 z-20 mt-1 max-h-64 overflow-y-auto rounded-xl border shadow-lg">
-                        {filteredGenreOptions.map((genre) => (
-                          <button
-                            key={genre}
-                            onClick={() => handleGenreSelect(genre)}
-                            className="hover:bg-muted/80 w-full px-4 py-2 text-left text-sm transition-all duration-200 first:rounded-t-xl last:rounded-b-xl"
-                          >
-                            {genre}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
+                  <select
+                    multiple
+                    size={6}
+                    value={selectedGenres}
+                    onChange={(e) =>
+                      setSelectedGenres(
+                        Array.from(e.target.selectedOptions).map((o) => o.value)
+                      )
+                    }
+                    className="bg-card border-border w-full rounded-lg border text-sm transition-all duration-300 focus:border-[var(--electric-green)]/40 focus:outline-none [&>option]:cursor-pointer [&>option]:px-3 [&>option]:py-2 [&>option:checked]:bg-[var(--deep-purple)] [&>option:checked]:text-white"
+                  >
+                    {allGenres.map((genre) => (
+                      <option key={genre} value={genre}>
+                        {genre}
+                      </option>
+                    ))}
+                  </select>
+                  <p className="text-muted-foreground mt-1.5 text-xs">
+                    Hold ⌘/Ctrl to select multiple
+                  </p>
                 </div>
               </div>
             </aside>

--- a/inertia/pages/search.tsx
+++ b/inertia/pages/search.tsx
@@ -252,10 +252,7 @@ export default function Search() {
       if (tagContainerRef.current && !tagContainerRef.current.contains(event.target as Node)) {
         setShowTagAutocomplete(false);
       }
-      if (
-        genreContainerRef.current &&
-        !genreContainerRef.current.contains(event.target as Node)
-      ) {
+      if (genreContainerRef.current && !genreContainerRef.current.contains(event.target as Node)) {
         setShowGenreAutocomplete(false);
       }
     };
@@ -318,7 +315,10 @@ export default function Search() {
               {showFilters ? 'HIDE_FILTERS' : 'SHOW_FILTERS'}
               {hasActiveFilters && (
                 <span className="text-background ml-1 rounded-full bg-[var(--electric-green)] px-2 py-0.5 text-xs">
-                  {selectedTypes.length + selectedTags.length + selectedGenres.length + (searchQuery ? 1 : 0)}
+                  {selectedTypes.length +
+                    selectedTags.length +
+                    selectedGenres.length +
+                    (searchQuery ? 1 : 0)}
                 </span>
               )}
             </button>

--- a/tests/functional/search.spec.ts
+++ b/tests/functional/search.spec.ts
@@ -12,7 +12,7 @@ type MediaItemShape = {
 };
 
 test.group('GET /search', () => {
-  test('returns Inertia search page with movies and shows', async ({ assert }) => {
+  test('returns Inertia search page with correct shape', async ({ assert }) => {
     const response = await fetch(`${BASE_URL}/search`, {
       headers: { 'X-Inertia': 'true', 'X-Inertia-Version': '1' },
     });
@@ -24,15 +24,7 @@ test.group('GET /search', () => {
     assert.equal(body.component, 'search');
     assert.isArray(body.props.movies);
     assert.isArray(body.props.shows);
-  });
 
-  test('each movie item includes a genres array and a valid type', async ({ assert }) => {
-    const response = await fetch(`${BASE_URL}/search`, {
-      headers: { 'X-Inertia': 'true', 'X-Inertia-Version': '1' },
-    });
-    const body = (await response.json()) as {
-      props: { movies: MediaItemShape[] };
-    };
     const validTypes = new Set(['movie', 'show', 'documentary']);
     for (const item of body.props.movies) {
       assert.isArray(item.genres, `genres should be an array on movie id=${item.id}`);
@@ -41,15 +33,6 @@ test.group('GET /search', () => {
         `type "${item.type}" is not valid on movie id=${item.id}`
       );
     }
-  });
-
-  test('each show item includes a genres array and type "show"', async ({ assert }) => {
-    const response = await fetch(`${BASE_URL}/search`, {
-      headers: { 'X-Inertia': 'true', 'X-Inertia-Version': '1' },
-    });
-    const body = (await response.json()) as {
-      props: { shows: MediaItemShape[] };
-    };
     for (const item of body.props.shows) {
       assert.isArray(item.genres, `genres should be an array on show id=${item.id}`);
       assert.equal(item.type, 'show', `type should be "show" on show id=${item.id}`);

--- a/tests/functional/search.spec.ts
+++ b/tests/functional/search.spec.ts
@@ -3,6 +3,14 @@ import { test } from '@japa/runner';
 
 const BASE_URL = `http://${process.env.HOST ?? '127.0.0.1'}:${process.env.PORT ?? '3333'}`;
 
+type MediaItemShape = {
+  id: number;
+  mediaType: 'movie' | 'tv';
+  type: 'movie' | 'show' | 'documentary';
+  genres: { name: string; slug: string }[];
+  tags: { name: string; slug: string }[];
+};
+
 test.group('GET /search', () => {
   test('returns Inertia search page with movies and shows', async ({ assert }) => {
     const response = await fetch(`${BASE_URL}/search`, {
@@ -11,10 +19,37 @@ test.group('GET /search', () => {
     assert.equal(response.status, 200);
     const body = (await response.json()) as {
       component: string;
-      props: { movies: unknown[]; shows: unknown[] };
+      props: { movies: MediaItemShape[]; shows: MediaItemShape[] };
     };
     assert.equal(body.component, 'search');
     assert.isArray(body.props.movies);
     assert.isArray(body.props.shows);
+  });
+
+  test('each movie item includes a genres array and a valid type', async ({ assert }) => {
+    const response = await fetch(`${BASE_URL}/search`, {
+      headers: { 'X-Inertia': 'true', 'X-Inertia-Version': '1' },
+    });
+    const body = (await response.json()) as {
+      props: { movies: MediaItemShape[] };
+    };
+    const validTypes = new Set(['movie', 'show', 'documentary']);
+    for (const item of body.props.movies) {
+      assert.isArray(item.genres, `genres should be an array on movie id=${item.id}`);
+      assert.isTrue(validTypes.has(item.type), `type "${item.type}" is not valid on movie id=${item.id}`);
+    }
+  });
+
+  test('each show item includes a genres array and type "show"', async ({ assert }) => {
+    const response = await fetch(`${BASE_URL}/search`, {
+      headers: { 'X-Inertia': 'true', 'X-Inertia-Version': '1' },
+    });
+    const body = (await response.json()) as {
+      props: { shows: MediaItemShape[] };
+    };
+    for (const item of body.props.shows) {
+      assert.isArray(item.genres, `genres should be an array on show id=${item.id}`);
+      assert.equal(item.type, 'show', `type should be "show" on show id=${item.id}`);
+    }
   });
 });

--- a/tests/functional/search.spec.ts
+++ b/tests/functional/search.spec.ts
@@ -36,7 +36,10 @@ test.group('GET /search', () => {
     const validTypes = new Set(['movie', 'show', 'documentary']);
     for (const item of body.props.movies) {
       assert.isArray(item.genres, `genres should be an array on movie id=${item.id}`);
-      assert.isTrue(validTypes.has(item.type), `type "${item.type}" is not valid on movie id=${item.id}`);
+      assert.isTrue(
+        validTypes.has(item.type),
+        `type "${item.type}" is not valid on movie id=${item.id}`
+      );
     }
   });
 

--- a/tests/unit/serializers/media_serializer.spec.ts
+++ b/tests/unit/serializers/media_serializer.spec.ts
@@ -91,7 +91,22 @@ test.group('serializeMovie', () => {
 
   test('type is "documentary" when genres include TMDB id 99', ({ assert }) => {
     const result = serializeMovie(
-      makeMovie({ genres: [{ id: 99, name: 'Documentary', slug: 'documentary' }] as unknown as Movie['genres'] })
+      makeMovie({
+        genres: [{ id: 99, name: 'Documentary', slug: 'documentary' }] as unknown as Movie['genres'],
+      })
+    );
+    assert.equal(result.type, 'documentary');
+  });
+
+  test('type is "documentary" when id 99 appears among multiple genres', ({ assert }) => {
+    const result = serializeMovie(
+      makeMovie({
+        genres: [
+          { id: 28, name: 'Action', slug: 'action' },
+          { id: 99, name: 'Documentary', slug: 'documentary' },
+          { id: 878, name: 'Science Fiction', slug: 'science-fiction' },
+        ] as unknown as Movie['genres'],
+      })
     );
     assert.equal(result.type, 'documentary');
   });

--- a/tests/unit/serializers/media_serializer.spec.ts
+++ b/tests/unit/serializers/media_serializer.spec.ts
@@ -23,6 +23,7 @@ function makeMovie(overrides: Partial<Movie> = {}): Movie {
       { name: 'hacking', slug: 'hacking' },
       { name: 'cyberpunk', slug: 'cyberpunk' },
     ],
+    genres: [{ id: 878, name: 'Science Fiction', slug: 'science-fiction' }],
     ...overrides,
   });
 }
@@ -42,6 +43,7 @@ function makeTvSeries(overrides: Partial<TvSeries> = {}): TvSeries {
       { name: 'hacking', slug: 'hacking' },
       { name: 'fsociety', slug: 'fsociety' },
     ],
+    genres: [{ id: 18, name: 'Drama', slug: 'drama' }],
     ...overrides,
   });
 }
@@ -69,6 +71,7 @@ test.group('serializeMovie', () => {
       { name: 'hacking', slug: 'hacking' },
       { name: 'cyberpunk', slug: 'cyberpunk' },
     ]);
+    assert.deepEqual(result.genres, [{ name: 'Science Fiction', slug: 'science-fiction' }]);
   });
 
   test('backdropPath is prefixed with backdropBaseUrl', ({ assert }) => {
@@ -81,9 +84,36 @@ test.group('serializeMovie', () => {
     assert.isUndefined(result.backdrop);
   });
 
-  test('type is hardcoded as "movie"', ({ assert }) => {
+  test('type defaults to "movie" when no documentary genre', ({ assert }) => {
     const result = serializeMovie(makeMovie());
     assert.equal(result.type, 'movie');
+  });
+
+  test('type is "documentary" when genres include TMDB id 99', ({ assert }) => {
+    const result = serializeMovie(
+      makeMovie({ genres: [{ id: 99, name: 'Documentary', slug: 'documentary' }] as unknown as Movie['genres'] })
+    );
+    assert.equal(result.type, 'documentary');
+  });
+
+  test('genres are mapped to MediaTag shape', ({ assert }) => {
+    const result = serializeMovie(
+      makeMovie({
+        genres: [
+          { id: 28, name: 'Action', slug: 'action' },
+          { id: 878, name: 'Science Fiction', slug: 'science-fiction' },
+        ] as unknown as Movie['genres'],
+      })
+    );
+    assert.deepEqual(result.genres, [
+      { name: 'Action', slug: 'action' },
+      { name: 'Science Fiction', slug: 'science-fiction' },
+    ]);
+  });
+
+  test('genres is [] when genres array is empty', ({ assert }) => {
+    const result = serializeMovie(makeMovie({ genres: [] as unknown as Movie['genres'] }));
+    assert.deepEqual(result.genres, []);
   });
 
   test('mediaType is hardcoded as "movie"', ({ assert }) => {
@@ -145,6 +175,7 @@ test.group('serializeTvSeries', () => {
       { name: 'hacking', slug: 'hacking' },
       { name: 'fsociety', slug: 'fsociety' },
     ]);
+    assert.deepEqual(result.genres, [{ name: 'Drama', slug: 'drama' }]);
   });
 
   test('backdropPath is prefixed with backdropBaseUrl', ({ assert }) => {
@@ -160,6 +191,28 @@ test.group('serializeTvSeries', () => {
   test('type is hardcoded as "show"', ({ assert }) => {
     const result = serializeTvSeries(makeTvSeries());
     assert.equal(result.type, 'show');
+  });
+
+  test('genres are mapped to MediaTag shape', ({ assert }) => {
+    const result = serializeTvSeries(
+      makeTvSeries({
+        genres: [
+          { id: 18, name: 'Drama', slug: 'drama' },
+          { id: 10765, name: 'Sci-Fi & Fantasy', slug: 'sci-fi-fantasy' },
+        ] as unknown as TvSeries['genres'],
+      })
+    );
+    assert.deepEqual(result.genres, [
+      { name: 'Drama', slug: 'drama' },
+      { name: 'Sci-Fi & Fantasy', slug: 'sci-fi-fantasy' },
+    ]);
+  });
+
+  test('genres is [] when genres array is empty', ({ assert }) => {
+    const result = serializeTvSeries(
+      makeTvSeries({ genres: [] as unknown as TvSeries['genres'] })
+    );
+    assert.deepEqual(result.genres, []);
   });
 
   test('mediaType is hardcoded as "tv"', ({ assert }) => {

--- a/tests/unit/serializers/media_serializer.spec.ts
+++ b/tests/unit/serializers/media_serializer.spec.ts
@@ -92,7 +92,9 @@ test.group('serializeMovie', () => {
   test('type is "documentary" when genres include TMDB id 99', ({ assert }) => {
     const result = serializeMovie(
       makeMovie({
-        genres: [{ id: 99, name: 'Documentary', slug: 'documentary' }] as unknown as Movie['genres'],
+        genres: [
+          { id: 99, name: 'Documentary', slug: 'documentary' },
+        ] as unknown as Movie['genres'],
       })
     );
     assert.equal(result.type, 'documentary');
@@ -224,9 +226,7 @@ test.group('serializeTvSeries', () => {
   });
 
   test('genres is [] when genres array is empty', ({ assert }) => {
-    const result = serializeTvSeries(
-      makeTvSeries({ genres: [] as unknown as TvSeries['genres'] })
-    );
+    const result = serializeTvSeries(makeTvSeries({ genres: [] as unknown as TvSeries['genres'] }));
     assert.deepEqual(result.genres, []);
   });
 

--- a/tests/unit/serializers/media_serializer.spec.ts
+++ b/tests/unit/serializers/media_serializer.spec.ts
@@ -113,6 +113,11 @@ test.group('serializeMovie', () => {
     assert.equal(result.type, 'documentary');
   });
 
+  test('type is "movie" when genres array is empty', ({ assert }) => {
+    const result = serializeMovie(makeMovie({ genres: [] as unknown as Movie['genres'] }));
+    assert.equal(result.type, 'movie');
+  });
+
   test('genres are mapped to MediaTag shape', ({ assert }) => {
     const result = serializeMovie(
       makeMovie({


### PR DESCRIPTION
## Summary

- **Bug fix**: `serializeMovie()` now detects TMDB genre ID 99 (Documentary) and sets `type: 'documentary'`, fixing the Type filter returning 0 results for documentaries on the search page
- **Bug fix**: Results grid key changed from `media.id` to `` `${media.mediaType}-${media.id}` ``, eliminating stale card rendering when text/tag filters are applied (TMDB movie and TV IDs overlap)
- **Feature**: Genres custom accessible listbox filter added to search sidebar (↑↓ navigate, Space to toggle, click to select, visual focus ring)
- **Feature**: Tags filter moved below Genres in the sidebar
- **UX**: Entering a search query clears all other active filters (type, tags, genres) so they don't compete
- **UX**: ↑↓ keyboard navigation in search title autocomplete and tags autocomplete dropdowns
- **UX**: Enter key in search input closes the autocomplete without selecting
- **UX**: X button appears in search input when a query is active — click to clear
- **UX**: CLEAR ALL button is now more prominent: purple in light mode, neon green in dark mode (was invisible in light mode)
- **UX**: Pointer cursor on all interactive elements: tag remove buttons, CLEAR ALL, type checkboxes, sort select, nav theme toggle, sign-in button
- **Style**: Description line clamp bumped from 3→4 (xl: 6) in search result cards
- **Fix**: Dockerfile now copies `patches/` directory before `pnpm install` (Docker build was broken)
- `MediaItem` now carries a `genres: MediaTag[]` field; both serializers populate it when genres are preloaded, falling back to `[]` otherwise (safe for controllers that don't preload genres)

Closes #21

## Test plan

- [x] All 85 backend tests pass (`node ace test`)
- [x] Precommit checks pass (lint, tsc, Prettier)
- [ ] Select "Documentary" in Type filter → ~101 results appear
- [ ] Type in search box → cards update in real time (not just the count)
- [ ] Select a tag → cards update (not just the count)
- [ ] Genres listbox filter appears above Tags in sidebar; ↑↓ + Space to keyboard-navigate/toggle
- [ ] Selecting genres filters results via inclusive OR
- [ ] Active genre pills appear in the filters row above results
- [ ] Entering a search query clears all other active filters
- [ ] CLEAR ALL resets genres, tags, types, and search together; button is visible in both light and dark mode
- [ ] X icon clears the search query when clicked
- [ ] Mobile filter count badge reflects active genre selections
- [ ] Dark and light themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)